### PR TITLE
Update Carthage example to double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ You can install Swiftline using CocoaPods, carthage and Swift package manager
     pod 'SwiftScanner'
 
 ### Carthage
-    github 'malcommac/SwiftScanner'
+    github "malcommac/SwiftScanner"
 
 ### Swift Package Manager
 Add swiftline as dependency in your `Package.swift`


### PR DESCRIPTION
Using single quotes in your Cartfile causes the error `Parse error: expected string after dependency type in line: github 'malcommac/SwiftScanner'`.

This PR updates the documentation so people won't run into the same issue if they copy-paste the example.